### PR TITLE
Embed returns the script element it embeds

### DIFF
--- a/js/puzzlescript-embed.js
+++ b/js/puzzlescript-embed.js
@@ -9,25 +9,26 @@
 			{
 				engine: "http://www.puzzlescript.net/js/scripts_play_compiled.js"
 			};
-		
+
 		extend(settings, config);
 		clear_children(element);
 		canvas = create_game_canvas(element, settings);
-		load_engine(element, id, settings, function()
+
+        return load_engine(element, id, settings, function()
 		{
 			window.canSetHTMLColors = false;
-			
+
 			if (Mobile.hasTouch())
 			{
 				canvas.onmousedown = function()
 				{
 					canvas.onmousedown = null;
-					
+
 					var gestureHandler = Mobile.enable();
-					
+
 					gestureHandler.setFocusElement(canvas);
 				}
-				
+
 				load_game(element, id, settings);
 			}
 			else
@@ -36,7 +37,7 @@
 			}
 		});
 	};
-	
+
 	function clear_children(element)
 	{
 		while (element.lastChild)
@@ -44,7 +45,7 @@
 			element.removeChild(element.lastChild);
 		}
 	}
-	
+
 	function create_game_canvas(element, id, settings)
 	{
 		var canvas = document.createElement("canvas");
@@ -52,19 +53,21 @@
 		element.appendChild(canvas);
 		return canvas;
 	}
-	
+
 	function load_engine(element, id, settings, onload)
 	{
 		var script = document.createElement("script");
 		script.setAttribute("src", settings.engine);
-		script.onload = onload;
+		script.addEventListener('load', onload, false);
 		document.body.appendChild(script);
+
+        return script;
 	}
-	
+
 	function load_game(element, id, settings, callback)
 	{
 		var githubURL = 'https://api.github.com/gists/' + id;
-		
+
 		var githubHTTPClient = new XMLHttpRequest();
 		githubHTTPClient.open('GET', githubURL);
 		githubHTTPClient.onreadystatechange = function () {
@@ -84,7 +87,7 @@
 		githubHTTPClient.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
 		githubHTTPClient.send();
 	}
-	
+
 	function extend(target, object)
 	{
 		if (typeof object !== 'undefined')
@@ -94,8 +97,8 @@
 				target[key] = object[key];
 			}
 		}
-		
+
 		return target;
 	}
-	
+
 })();

--- a/js/puzzlescript-embed.js
+++ b/js/puzzlescript-embed.js
@@ -14,7 +14,7 @@
 		clear_children(element);
 		canvas = create_game_canvas(element, settings);
 
-        return load_engine(element, id, settings, function()
+		return load_engine(element, id, settings, function()
 		{
 			window.canSetHTMLColors = false;
 
@@ -60,8 +60,7 @@
 		script.setAttribute("src", settings.engine);
 		script.addEventListener('load', onload, false);
 		document.body.appendChild(script);
-
-        return script;
+		return script;
 	}
 
 	function load_game(element, id, settings, callback)


### PR DESCRIPTION
Hello! This is arrogantgamer.

I made it so embed returns the script tag it embeds, and I changed an `onload =` into an `addEventListener` so that users (me) can hang further onload handlers off of the puzzlescript engine's onload event. 

I did this for my own special sneaky purposes, but I figure someone else might find it useful some day. (I used it to wrap some advice around `onKeyUp` and `onKeyDown`)
